### PR TITLE
adjust deployment command to the correct one

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,7 @@ name: create Preview Cloudflare worker
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
-
+jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy Versions
@@ -14,4 +14,4 @@ on:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-        run: npm run preview
+        run: npm run deploy:version

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"start": "next start",
 		"lint": "next lint",
 		"deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
-		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
+		"deploy:version": "opennextjs-cloudflare build && npx wrangler versions upload",
+    "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts"
 	},
 	"dependencies": {


### PR DESCRIPTION
I actually came across two implementations problems here, some #copypasta and the second was a snag on a [limitation by cloudflare](https://developers.cloudflare.com/workers/configuration/previews/\#limitations) 

Tucked at the bottom of the page, is the information, that any site that uses durable objects will not get a preview url.

I was playing around with openNext caching
https://opennext.js.org/cloudflare/caching

and inadvertently disabled preview urls

fix, delete expereiment, i still have to figure out a terraform/cdk esque way of interacting with cloudflare