### PR TITLE
Add e2e after deploy to production

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,9 +5,9 @@ on:
       - main
 
 jobs:
-  deploy:
+  deploy-production:
     runs-on: ubuntu-latest
-    name: Deploy
+    name: 🟧 Deploy production 🟧
     steps:
       - uses: actions/checkout@v4
       - name: install
@@ -17,3 +17,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: npm run deploy
+  e2e:
+    needs: deploy-production
+    uses: mcgoooo/mcgoooo-world/.github/workflows/e2e.yaml@main
+    with:
+      playwright-base-url: "https://mcgoooo.world"


### PR DESCRIPTION
this was made eady by reusing the previous pulls
workflow.

For the moment, we have hardcoded mcgooo.world.
once we have a mono repo. This will be abstracted.

This was tested by a push to main here
https://github.com/mcgoooo/mcgoooo-world/actions/runs/16368700263 which was reverted, the site is not live.